### PR TITLE
allow primer lengths to be 0. use new docker image

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
     design = false
 
     // Input Options
-    forward_primer_length = 16
+    forward_primer_length = 17
     reverse_primer_length = 24
     amplicon_length = 510
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -33,23 +33,23 @@
             "properties": {
                 "forward_primer_length": {
                     "type": "integer",
-                    "description": "Length of the forward primer",
-                    "minimum": 1,
-                    "maximum": 50,
-                    "default": 16
+                    "description": "Length of the forward primer, excluding the adapter. For example, the forward primer sequence in the Zymo Quick 16S Plus Kit (V3-V4) is CCTACGGGDGGCWGCAG, whihc is 17 bp long.",
+                    "minimum": 0,
+                    "maximum": 30,
+                    "default": 17
                 },
                 "reverse_primer_length": {
                     "type": "integer",
-                    "description": "Length of the reverse primer",
-                    "minimum": 1,
-                    "maximum": 50,
+                    "description": "Length of the reverse primer, excluding the adapter. For example, the reverse primer sequence in the Zymo Quick 16S Plus Kit (V3-V4) is GACTACNVGGGTMTCTAATCC, which is 24 bp long.",
+                    "minimum": 0,
+                    "maximum": 30,
                     "default": 24
                 },
                 "amplicon_length": {
                     "type": "integer",
-                    "description": "Length of the amplicon",
+                    "description": "The maximum expected length of the amplicon, including the primers.",
                     "minimum": 1,
-                    "maximum": 5000,
+                    "maximum": 1000,
                     "default": 510
                 }
             },

--- a/processes/miqscore16s.nf
+++ b/processes/miqscore16s.nf
@@ -5,7 +5,7 @@ params.reverse_primer_length = 24
 params.amplicon_length = 510
 
 process miqscore16s {
-    container 'zymoresearch/miqscore16s:latest'
+    container 'zymoresearch/miqscore16s:110723'
     publishDir "${params.publish_dir}", mode: 'copy'
 
     input:


### PR DESCRIPTION
The new version of the miqscore16S source code supports primer lengths of zeros. This update uses a new docker image that supports this function. Also updates the schema to allow zeros for the two primer length parameters. 